### PR TITLE
Update times to be float64s for timing precision better than 10 seconds

### DIFF
--- a/scripts/eleanor-postcards
+++ b/scripts/eleanor-postcards
@@ -129,7 +129,7 @@ def make_postcards(fns, outdir, width=104, height=148, wstep=None, hstep=None):
     # time dependent header info
     primary_cols = ["TSTART", "TSTOP", "BARYCORR", "DATE-OBS", "DATE-END",
                     "BKG", "QUALITY", "FFIINDEX"]
-    primary_dtype = [np.float32, np.float32, np.float32, "O", "O", np.float32,
+    primary_dtype = [np.float64, np.float64, np.float32, "O", "O", np.float32,
                      np.int64, np.int64]
     primary_data = np.empty(len(fns), list(zip(primary_cols, primary_dtype)))
 


### PR DESCRIPTION
Note that I left the barycentric correction as a float32. This is in line with the data types of the official TESS short cadence light curves, which also have tstart and tstop as 64 bit but barycorr as 32. This is because the 8 digits of barycentric precision is enough to get to the 11th decimal place, since they always start as 0.000XXX.