### PR TITLE
adding crowded_field flag to script to only use small apertures for faint targets

### DIFF
--- a/scripts/eleanor-light-curves
+++ b/scripts/eleanor-light-curves
@@ -19,7 +19,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 
 FMT = "hlsp_eleanor_tess_ffi_tic{0}_s{1:04d}_tess_v1_lc.fits"
-
+crowding_limit = 14.0
 
 def make_light_curves(directory, sector, camera, ccd, **kwargs):
     sector_path = "s{0:04d}".format(sector)
@@ -34,7 +34,7 @@ def make_light_curves(directory, sector, camera, ccd, **kwargs):
     print(star.pointing)
     star.tess_mag = tess_mag
 
-    if star.tess_mag < 14:
+    if star.tess_mag < crowding_limit:
         crowded_field = False
     else:
         crowded_field = True

--- a/scripts/eleanor-light-curves
+++ b/scripts/eleanor-light-curves
@@ -32,8 +32,14 @@ def make_light_curves(directory, sector, camera, ccd, **kwargs):
     )
     print(star.pm_dir)
     print(star.pointing)
+    star.tess_mag = tess_mag
+
+    if star.tess_mag < 14:
+        crowded_field = False
+    else:
+        crowded_field = True
     data = eleanor.TargetData(
-        star, do_pca=True, do_psf=False
+        star, do_pca=True, do_psf=False, crowded_field = crowded_field
     )  # , height=13, bkg_size=21,)
 
     tic_id = data.source_info.tic
@@ -64,4 +70,5 @@ if __name__ == "__main__":
         coords=SkyCoord(ra=68.959732, dec=-64.02704, unit=(u.deg, u.deg)),
         tic=38846515,
         gaia=0,
+        tess_mag = 10.1
     )


### PR DESCRIPTION
This performs better for faint targets that otherwise would try to use a big aperture to encompass a nearby bright star.