### PR TITLE
ignore all-0 frames in background calculation

### DIFF
--- a/scripts/eleanor-backgrounds
+++ b/scripts/eleanor-backgrounds
@@ -51,9 +51,10 @@ def calc_2dbkg(flux, qual, time, fast=True):
 
     q = qual == 0
 
+    nonzero = (flux.sum(axis=(0,1)) > 0)
     # build a single frame in shape of detector.
     # This was once the median image, not sure why it was changed
-    med = np.percentile(flux[:, :, :], 1, axis=(2))
+    med = np.percentile(flux[:, :, nonzero], 1, axis=(2))
 
     # subtract off median to remove stable background emission, which is
     # especially apparent in corners


### PR DESCRIPTION
Hey,

We just hit an error in building postcards and I think this fixes it. Though I'm a bit puzzled why this didn't happen for you before.

What you're currently doing is grabbing the 1st percentile cadence in terms of total flux as some sort of reference frame I think. I suspect the reason for choosing 1st percentile is to find the "quietest" part of the sector where overall background scatter is minimized regardless of the details of the Earth/moon orientation for that sector.

However, in sector 5, we have a postcard where the last 13 cadences are all zeros (I believe because this is when the detector saturates as the Earth passes directly through the FOV. There are 1196 cadences, so the 1st percentile is the 12th lowest flux frame, which happens to be one of the all-zero frames.

My fix is to just ignore all-zero cadences in the "1st percentile" flux calculation, which seems to fix the problem. 

