### PR TITLE
another issue with postcard creation

### DIFF
--- a/scripts/eleanor-backgrounds
+++ b/scripts/eleanor-backgrounds
@@ -51,7 +51,7 @@ def calc_2dbkg(flux, qual, time, fast=True):
 
     q = qual == 0
 
-    nonzero = (flux.sum(axis=(0,1)) > 0)
+    nonzero = (flux.sum(axis=(0,1)) != 0)
     # build a single frame in shape of detector.
     # This was once the median image, not sure why it was changed
     med = np.percentile(flux[:, :, nonzero], 1, axis=(2))


### PR DESCRIPTION
In sector 7 our build failed again. This time because it was claiming that there are no cadences where `flux.sum(axis=(0,1))` is greater than 0. That sounded ridiculous especially since it was saying that the median cadence value of `flux.sum(axis=(0,1))` was -89373140.

Plotting the postcard up showed what the problem is:
![Figure_2](https://user-images.githubusercontent.com/6944089/159580950-0011f0b3-547c-4e04-a5ec-ea4e3c6ae722.png)

The bright star saturates several columns and apparently the negative values significantly overcome the positive. So now I'm switching to only throwing out exactly `flux.sum(axis=(0,1)) == 0`  sums, which like I found before is when whole detector saturates and they throw things out.

This fixed all our issues in this sector.